### PR TITLE
adds-delete-comment-by-id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -79,7 +79,7 @@ describe("GET /api/articles/:article_id", () => {
     .get("/api/articles/999")
     .expect(404)
     .then(( {body} ) => {
-        expect(body.msg).toBe('404 - Not Found')
+        expect(body.msg).toBe('404 - Article Not Found')
     })
   })
   test("GET 400: should respond with '400 - Bad Request' when passed an invalid id number", () => {
@@ -160,7 +160,7 @@ describe("GET api/articles/:article_id/comments", () => {
     .get("/api/articles/9999/comments")
     .expect(404)
     .then(( {body} ) => {
-      expect(body.msg).toBe('404 - Not Found')
+      expect(body.msg).toBe('404 - Article Not Found')
     })
   })
   test("GET 400: when input an invalid id, should respond with '400 - Bad Request", () => {
@@ -267,7 +267,7 @@ describe("PATCH /api/articles/:article_id", () => {
     .send(voteChanger)
     .expect(404)
     .then(({body}) => {
-      expect(body.msg).toBe('404 - Not Found')
+      expect(body.msg).toBe('404 - Article Not Found')
     })
   })
   test("PATCH 400: when given an invalid article id, should respond with '400 - Bad Request'", () => {
@@ -297,6 +297,30 @@ describe("PATCH /api/articles/:article_id", () => {
     .send(voteChanger)
     .expect(400)
     .then(( {body} ) => {
+      expect(body.msg).toBe('400 - Bad Request')
+    })
+  })
+})
+
+describe("DELETE /api/comments/comment_id", () => {
+  test("DELETE 204: should respond with a status code of 204", () => {
+    return request(app)
+    .delete("/api/comments/1")
+    .expect(204)
+  })
+  test("DELETE 404: when trying to delete using a valid, but non-existent id, should respond with '404 - Comment Not Found'", () => {
+    return request(app)
+    .delete("/api/comments/9999")
+    .expect(404)
+    .then(({body}) => {
+      expect(body.msg).toBe('404 - Comment Not Found')
+    })
+  })
+  test("DELETE 400: when trying to delete using an invalid id, should respond with '400 - Bad Request'", () => {
+    return request(app)
+    .delete("/api/comments/comment-twelve")
+    .expect(400)
+    .then(({body}) => {
       expect(body.msg).toBe('400 - Bad Request')
     })
   })

--- a/app.js
+++ b/app.js
@@ -5,11 +5,13 @@ const {getEndpoints} = require("./controllers/get-endpoint-controller")
 // article 37 appears with \n, why?
 const articlesRoute = require("./routers/articles-router")
 const topicsRouter = require("./routers/topics-router")
+const commentsRouter = require("./routers/comments-router")
 
 app.use(express.json())
 
 app.use('/api/articles', articlesRoute)
 app.use('/api/topics', topicsRouter)
+app.use('/api/comments', commentsRouter)
 
 app.get("/api", getEndpoints)
 

--- a/controllers/comments-controller.js
+++ b/controllers/comments-controller.js
@@ -1,5 +1,5 @@
-const {fetchCommentsByArticleId, insertComment} = require("../models/comments-model")
-const {doesArticleExist} = require("../utils.js")
+const {fetchCommentsByArticleId, insertComment, removeComment } = require("../models/comments-model")
+const { doesArticleExist, doesCommentExist } = require("../utils.js")
 
 exports.getCommentsByArticleId = (req, res, next) => {
     const articleId = req.params.article_id
@@ -27,5 +27,17 @@ exports.postComment = (req, res, next) => {
     })
 }
 
-
+exports.deleteCommentById = (req, res, next) => {
+    const commentId = req.params.comment_id
+    doesCommentExist(commentId)
+    .then(() => {
+        return removeComment(commentId)
+        .then(() => {
+            res.status(204).send({msg:`Comment has been deleted`})
+        })
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -72,5 +72,9 @@
       "created_at": "String of date and time of post creation",
       "article_id": 1
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes the specified comment and responds only with a 204 status code", 
+    "queries": []
   }
 }

--- a/models/comments-model.js
+++ b/models/comments-model.js
@@ -13,3 +13,7 @@ exports.insertComment = (newComment, articleId) => {
         return rows[0]
     })
 }
+
+exports.removeComment = (commentId) => {
+    return db.query(`DELETE FROM comments WHERE comment_id=$1`, [commentId])
+}

--- a/routers/comments-router.js
+++ b/routers/comments-router.js
@@ -1,0 +1,7 @@
+const express = require("express")
+const router = express.Router()
+const { deleteCommentById } = require("../controllers/comments-controller")
+
+router.delete("/:comment_id", deleteCommentById)
+
+module.exports = router

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,17 @@ exports.doesArticleExist = (articleId) => {
     .then(({rows}) => {
         if(rows.length === 0){
             return Promise.reject({
-            status: 404, msg: '404 - Not Found'
+            status: 404, msg: '404 - Article Not Found'
+        })}
+    })
+}
+
+exports.doesCommentExist = (commentId) => {
+    return db.query(`SELECT * FROM comments WHERE comment_id = $1`, [commentId])
+    .then(({rows}) => {
+        if(rows.length === 0){
+            return Promise.reject({
+            status: 404, msg: '404 - Comment Not Found'
         })}
     })
 }


### PR DESCRIPTION
updated endpoints.json to include delete comment by id

tested for delete comments
200
404
400
created doesCommentExist function
created deleteCommentById functions

made tests more specific (404 - **article** not found) due to increase in complexity of error handling methods